### PR TITLE
Feature/cat data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10851,6 +10851,20 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "react-flip-move": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
+      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q=="
+    },
+    "react-images-upload": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-images-upload/-/react-images-upload-1.2.8.tgz",
+      "integrity": "sha512-d5mhAE0BfkLTlG5MLvKVw+q76LL8r5easgWW0TTBvXD8n6HXeLMZLwCuPiOibY1a3NRMXI4AnM1r34dqLOBjng==",
+      "requires": {
+        "react": "^16.12.0",
+        "react-flip-move": "^3.0.4"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lodash": "^4.17.20",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-images-upload": "^1.2.8",
     "react-redux": "^7.2.1",
     "react-scripts": "3.4.3",
     "redux": "^4.0.5",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,15 +1,16 @@
 import catAPI from '../apis/catAPI';
 
 export const fetchCats =() => async dispatch => {
-    const response = await catAPI.get('/search')
+    const response = await catAPI.get('/search?limit=20&size=med')
 
     dispatch({ type: 'FETCH_CATS', payload: response.data });
 
 };
 
 export const sendCats =() => async dispatch => {
+    console.log('action2')
     const response = await catAPI.put('/upload')
-
+    console.log('action2', response)
     dispatch({ type: 'SEND_CATS', payload: response.data });
 
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -9,7 +9,7 @@ export const fetchCats =() => async dispatch => {
 
 export const sendCats =() => async dispatch => {
     console.log('action2')
-    const response = await catAPI.put('/upload')
+    const response = await catAPI.post('/upload')
     console.log('action2', response)
     dispatch({ type: 'SEND_CATS', payload: response.data });
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,8 +1,9 @@
-import catAPI from './apis/catAPI';
+import catAPI from '../apis/catAPI';
 
 export const fetchCats =() => async dispatch => {
-    const response = await catAPI.get('/images');
-
+    console.log('action')
+    const response = await catAPI.get('https://api.thecatapi.com/v1/images/search')
+    console.log(response, 'response')
    dispatch({ type: 'FETCH_CATSS', payload: response.data });
 
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,6 +3,6 @@ import catAPI from '../apis/catAPI';
 export const fetchCats =() => async dispatch => {
     const response = await catAPI.get('https://api.thecatapi.com/v1/images/search')
 
-   dispatch({ type: 'FETCH_CATS', payload: response.data });
+    dispatch({ type: 'FETCH_CATS', payload: response.data });
 
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -7,10 +7,9 @@ export const fetchCats =() => async dispatch => {
 
 };
 
+// TODO: figure out how to upload images
 export const sendCats =() => async dispatch => {
-    console.log('action2')
     const response = await catAPI.post('/upload')
-    console.log('action2', response)
     dispatch({ type: 'SEND_CATS', payload: response.data });
 
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,8 +1,15 @@
 import catAPI from '../apis/catAPI';
 
 export const fetchCats =() => async dispatch => {
-    const response = await catAPI.get('https://api.thecatapi.com/v1/images/search')
+    const response = await catAPI.get('/search')
 
     dispatch({ type: 'FETCH_CATS', payload: response.data });
+
+};
+
+export const sendCats =() => async dispatch => {
+    const response = await catAPI.put('/upload')
+
+    dispatch({ type: 'SEND_CATS', payload: response.data });
 
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,9 +1,8 @@
 import catAPI from '../apis/catAPI';
 
 export const fetchCats =() => async dispatch => {
-    console.log('action')
     const response = await catAPI.get('https://api.thecatapi.com/v1/images/search')
-    console.log(response, 'response')
-   dispatch({ type: 'FETCH_CATSS', payload: response.data });
+
+   dispatch({ type: 'FETCH_CATS', payload: response.data });
 
 };

--- a/src/apis/catAPI.js
+++ b/src/apis/catAPI.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+axios.defaults.headers.common['x-api-key'] = 'd8a26c63-f8d5-44e4-93ce-e80444c0a743';
+
 export default axios.create({
-    baseURL: 'https://api.thecatapi.com/v1/images/search'
+    baseURL: 'https://api.thecatapi.com/v1/images'
 });

--- a/src/apis/catAPI.js
+++ b/src/apis/catAPI.js
@@ -3,5 +3,5 @@ import axios from 'axios';
 axios.defaults.headers.common['x-api-key'] = 'd8a26c63-f8d5-44e4-93ce-e80444c0a743';
 
 export default axios.create({
-    baseURL: 'https://api.thecatapi.com/v1/images'
+    baseURL: 'https://api.thecatapi.com/v1/'
 });

--- a/src/apis/catAPI.js
+++ b/src/apis/catAPI.js
@@ -3,5 +3,5 @@ import axios from 'axios';
 axios.defaults.headers.common['x-api-key'] = 'd8a26c63-f8d5-44e4-93ce-e80444c0a743';
 
 export default axios.create({
-    baseURL: 'https://api.thecatapi.com/v1/'
+    baseURL: 'https://api.thecatapi.com/v1/images'
 });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,7 +6,7 @@ import Splash from './Splash';
 
 function App() {
   return (
-    <div className="App" style={{fontFamily: 'Rock Salt'}}>
+    <div className="App" style={{fontFamily: 'Rock Salt !important'}}>
       <CatList /> 
       <Splash />
     </div>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,15 +1,20 @@
 import React from 'react';
+import styled from 'styled-components';
 import '../App.css';
 import CatList from './CatList';
 import Splash from './Splash';
 
+const MainApp = styled.div `
+  font-family: Rock Salt !important;
+`
+
 
 function App() {
   return (
-    <div className="App" style={{fontFamily: 'Rock Salt !important'}}>
+    <MainApp className="App" style={{fontFamily: 'Rock Salt !important'}}>
       <CatList /> 
       <Splash />
-    </div>
+    </MainApp>
   );
 }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,8 +7,7 @@ import Splash from './Splash';
 function App() {
   return (
     <div className="App" style={{fontFamily: 'Rock Salt'}}>
-      {/* app
-      <CatList /> */}
+      <CatList /> 
       <Splash />
     </div>
   );

--- a/src/components/CatDetail.js
+++ b/src/components/CatDetail.js
@@ -1,8 +1,27 @@
 import React from 'react';
+import styled from 'styled-components';
 
-const CatDetail = () => {
+const CatBox = styled.div `
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 100px;
+`
+
+const catCard = {
+    width: '50%',
+    height: 'auto',
+    border: '1px solid black',
+    backgroundImage: `url(${props => props.catUrl})`,
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center',
+}
+    
+const CatDetail = (props) => {   
     return (
-        <div>Cat Detail</div>
+        <CatBox>
+            <img src={props.catUrl} style={catCard} /> 
+        </CatBox>
     )
 };
 

--- a/src/components/CatDetail.js
+++ b/src/components/CatDetail.js
@@ -38,7 +38,10 @@ const CatDetail = (props) => {
             >
                 Prev
                 <Icon name='left arrow' />
-            </Button>    
+            </Button> 
+            <Button icon onClick={props.sendCats} >
+                <Icon name='caret square up outline' />
+            </Button>   
             <Button 
             icon 
             labelPosition='right'

--- a/src/components/CatDetail.js
+++ b/src/components/CatDetail.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Button, Icon } from 'semantic-ui-react'
 
 const CatBox = styled.div `
     display: flex;
@@ -21,37 +20,18 @@ const CatCard = {
 }
 
 const ButtonBox = styled.div `
-
+    margin-left: 5px;
+    margin-right: 5px;
 `
     
 const CatDetail = (props) => {   
+    
     return (
         <CatBox>
             <div>
                 <img src={props.catUrl} style={CatCard} /> 
             </div>
-        <ButtonBox>
-            <Button 
-            icon 
-            labelPosition='left'
-            // onClick={props.fetchCats}
-            >
-                Prev
-                <Icon name='left arrow' />
-            </Button> 
-            <Button icon onClick={props.sendCats} >
-                <Icon name='caret square up outline' />
-            </Button>   
-            <Button 
-            icon 
-            labelPosition='right'
-            onClick={props.fetchCats}
-            >
-                Next
-                <Icon name='right arrow' />
-            </Button>
-        </ButtonBox>    
-    </CatBox>    
+        </CatBox>    
     )
 };
 

--- a/src/components/CatDetail.js
+++ b/src/components/CatDetail.js
@@ -1,27 +1,54 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Button, Icon } from 'semantic-ui-react'
 
 const CatBox = styled.div `
     display: flex;
     justify-content: center;
     align-items: center;
     margin-top: 100px;
+    margin-bottom: 100px;
+    flex-direction: column;
 `
 
-const catCard = {
-    width: '50%',
+const CatCard = {
     height: 'auto',
+    padding: '2px',
     border: '1px solid black',
     backgroundImage: `url(${props => props.catUrl})`,
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'center',
 }
+
+const ButtonBox = styled.div `
+
+`
     
 const CatDetail = (props) => {   
     return (
         <CatBox>
-            <img src={props.catUrl} style={catCard} /> 
-        </CatBox>
+            <div>
+                <img src={props.catUrl} style={CatCard} /> 
+            </div>
+        <ButtonBox>
+            <Button 
+            icon 
+            labelPosition='left'
+            // onClick={props.fetchCats}
+            >
+                Prev
+                <Icon name='left arrow' />
+            </Button>    
+            <Button 
+            icon 
+            labelPosition='right'
+            onClick={props.fetchCats}
+            >
+                Next
+                <Icon name='right arrow' />
+            </Button>
+        </ButtonBox>    
+    </CatBox>    
     )
 };
 

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -5,6 +5,13 @@ import { Button, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
 import CatDetail from './CatDetail';
 
+const MainContainer = styled.div `
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 100px;
+`
+
 const ButtonBox = styled.div `
     margin-left: 5px;
     margin-right: 5px;
@@ -56,30 +63,34 @@ class Catlist extends React.Component {
 
     render(){
         return (
-            <div>
+            <MainContainer>
                 {this.renderCat()}
-                <ButtonBox>
-                    <Button 
-                    icon 
-                    labelPosition='left'
-                    onClick={this.handlePrevClick}
-                    >
-                        Prev
-                        <Icon name='left arrow' />
-                    </Button> 
-                    <Button icon  >
-                        <Icon name='caret square up outline' />
-                    </Button>   
-                    <Button 
-                    icon 
-                    labelPosition='right'
-                    onClick={this.handleNextClick}
-                    >
-                        Next
-                        <Icon name='right arrow' />
-                    </Button>
-                </ButtonBox> 
-            </div>
+                {this.state.showCat ? 
+                    <ButtonBox>
+                        <Button 
+                        icon 
+                        labelPosition='left'
+                        onClick={this.handlePrevClick}
+                        >
+                            Prev
+                            <Icon name='left arrow' />
+                        </Button> 
+                        <Button icon  >
+                            <Icon name='caret square up outline' />
+                        </Button>   
+                        <Button 
+                        icon 
+                        labelPosition='right'
+                        onClick={this.handleNextClick}
+                        >
+                            Next
+                            <Icon name='right arrow' />
+                        </Button>
+                    </ButtonBox> 
+                :
+                ''
+                }
+            </MainContainer>
         )
     }
 };

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -1,12 +1,35 @@
-import React from 'react';
+import React , { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+import { fetchCats } from '../actions';
 import CatDetail from './CatDetail';
 
-const Catlist = () => {
-    return (
-        <div>Catlist
-            <CatDetail />
-        </div>
-    )
+class Catlist extends React.Component {
+
+    componentDidMount() {
+        this.props.fetchCats();
+        console.log('here')
+    }
+// const Catlist = () => {
+//     const [cat, setCat] = useState();
+
+    // useEffect(() => {
+    //     fetchCats();
+    //     console.log('here')
+    // }); 
+
+    // fetchCats();
+
+    render(){
+        return (
+            <div>Catlist
+                <CatDetail />
+            </div>
+        )
+    }
 };
 
-export default Catlist;
+const mapStateToProps = (state) => {
+    return { cat: state.cat };
+}
+
+export default connect(mapStateToProps,{ fetchCats })(Catlist);

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -75,7 +75,7 @@ class Catlist extends React.Component {
                             Prev
                             <Icon name='left arrow' />
                         </Button> 
-                        <Button icon  >
+                        <Button icon onClick={this.props.sendCats()} >
                             <Icon name='caret square up outline' />
                         </Button>   
                         <Button 

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -1,29 +1,25 @@
-import React , { useState, useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { fetchCats } from '../actions';
 import CatDetail from './CatDetail';
 
 class Catlist extends React.Component {
-    constructor(props) {
-        super(props);
-        // this.state = [];
-      }
+    constructor(props){
+        super(props)
+        this.state = {showCat: false};
+    } 
 
     componentDidMount() {
         this.props.fetchCats();
-        console.log('here mount', this.props.cats)
+        setTimeout(() => this.setState({showCat: true}), 7000);
     }
 
-    // componentDidUpdate(prevProps, prevState) {
-    //     console.log(this.props.cats, this.props, this.state, 'update', prevProps, prevState,)
-    // }
     renderCat() {
         return this.props.cats.map(cat => {
             return (
                 <div key={cat.id}>
                     <div>
-                        <h2>{cat.url}</h2>
-                        <p>{cat.breed}</p>
+                    {this.state.showCat ? <CatDetail catUrl={cat.url} /> : ''}
                     </div>
                 </div>
             )
@@ -34,7 +30,6 @@ class Catlist extends React.Component {
         console.log(this.state, 'state in render', this.props.cats)
         return (
             <div>
-                <CatDetail />
                 {this.renderCat()}
             </div>
         )

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -6,7 +6,10 @@ import CatDetail from './CatDetail';
 class Catlist extends React.Component {
     constructor(props){
         super(props)
-        this.state = {showCat: false};
+        this.state = {
+            showCat: false,
+            catArr: []
+        };
     } 
 
     componentDidMount() {
@@ -19,7 +22,7 @@ class Catlist extends React.Component {
             return (
                 <div key={cat.id}>
                     <div>
-                    {this.state.showCat ? <CatDetail catUrl={cat.url} /> : ''}
+                    {this.state.showCat ? <CatDetail catUrl={cat.url} fetchCats={this.props.fetchCats} /> : ''}
                     </div>
                 </div>
             )
@@ -27,7 +30,6 @@ class Catlist extends React.Component {
     };
 
     render(){
-        console.log(this.state, 'state in render', this.props.cats)
         return (
             <div>
                 {this.renderCat()}
@@ -36,8 +38,12 @@ class Catlist extends React.Component {
     }
 };
 
-const mapStateToProps = (state, ownProps) => {
+// const mapDispatchToProps = dispatch => ({
+//     fetchCats: () => dispatch(fetchCats())
+//   })
+
+const mapStateToProps = (state) => {
     return { cats: state.cats };
 }
 
-export default connect(mapStateToProps,{ fetchCats })(Catlist);
+export default connect(mapStateToProps, { fetchCats })(Catlist);

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -1,14 +1,22 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { fetchCats, sendCats } from '../actions';
+import { Button, Icon } from 'semantic-ui-react';
+import styled from 'styled-components';
 import CatDetail from './CatDetail';
+
+const ButtonBox = styled.div `
+    margin-left: 5px;
+    margin-right: 5px;
+`
 
 class Catlist extends React.Component {
     constructor(props){
         super(props)
         this.state = {
             showCat: false,
-            catArr: []
+            catArr: [],
+            currentIndex: 0
         };
     } 
 
@@ -17,13 +25,30 @@ class Catlist extends React.Component {
         setTimeout(() => this.setState({showCat: true}), 7000);
     }
 
+    componentDidUpdate(prevState, prevProps){
+        if (prevState.cats.length !== this.state.catArr.length) {
+            this.setState({ catArr: this.state.catArr.concat(prevState.cats)}) 
+        }
+    }
+
+    handleNextClick = () =>  {
+        this.setState({currentIndex: this.state.currentIndex + 1})
+    }
+
+    handlePrevClick = () =>  {
+        this.setState({currentIndex: this.state.currentIndex - 1})
+    }
+
     renderCat() {
-        return this.props.cats.map(cat => {
+        let props = {
+            catArr: this.state.catArr,
+            fetchCats: this.props.fetchCats,
+            sendeCats: this.props.sendCats
+        }
+        return this.props.cats.map((cat, index) => {
             return (
                 <div key={cat.id}>
-                    <div>
-                    {this.state.showCat ? <CatDetail catUrl={cat.url} fetchCats={this.props.fetchCats} sendeCats={this.props.sendCats} /> : ''}
-                    </div>
+                    {this.state.showCat && this.state.currentIndex === index ? <CatDetail {...props} catUrl = {cat.url} index = {this.state.currentIndex} /> : ''}
                 </div>
             )
         })
@@ -33,14 +58,31 @@ class Catlist extends React.Component {
         return (
             <div>
                 {this.renderCat()}
+                <ButtonBox>
+                    <Button 
+                    icon 
+                    labelPosition='left'
+                    onClick={this.handlePrevClick}
+                    >
+                        Prev
+                        <Icon name='left arrow' />
+                    </Button> 
+                    <Button icon  >
+                        <Icon name='caret square up outline' />
+                    </Button>   
+                    <Button 
+                    icon 
+                    labelPosition='right'
+                    onClick={this.handleNextClick}
+                    >
+                        Next
+                        <Icon name='right arrow' />
+                    </Button>
+                </ButtonBox> 
             </div>
         )
     }
 };
-
-// const mapDispatchToProps = dispatch => ({
-//     fetchCats: () => dispatch(fetchCats())
-//   })
 
 const mapStateToProps = (state) => {
     return { cats: state.cats };

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { fetchCats } from '../actions';
+import { fetchCats, sendCats } from '../actions';
 import CatDetail from './CatDetail';
 
 class Catlist extends React.Component {
@@ -22,7 +22,7 @@ class Catlist extends React.Component {
             return (
                 <div key={cat.id}>
                     <div>
-                    {this.state.showCat ? <CatDetail catUrl={cat.url} fetchCats={this.props.fetchCats} /> : ''}
+                    {this.state.showCat ? <CatDetail catUrl={cat.url} fetchCats={this.props.fetchCats} sendeCats={this.props.sendCats} /> : ''}
                     </div>
                 </div>
             )
@@ -46,4 +46,4 @@ const mapStateToProps = (state) => {
     return { cats: state.cats };
 }
 
-export default connect(mapStateToProps, { fetchCats })(Catlist);
+export default connect(mapStateToProps, { fetchCats, sendCats })(Catlist);

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import ImageUploader from 'react-images-upload';
 import { fetchCats, sendCats } from '../actions';
 import { Button, Icon } from 'semantic-ui-react';
 import styled from 'styled-components';
@@ -17,13 +18,20 @@ const ButtonBox = styled.div `
     margin-right: 5px;
 `
 
+const hideStyles = {
+    hieght: '20px',
+    width: '30px',
+    color: 'inherit'
+}
+
 class Catlist extends React.Component {
     constructor(props){
         super(props)
         this.state = {
             showCat: false,
-            catArr: [],
-            currentIndex: 0
+            catArr: this.props.cats,
+            currentIndex: 0,
+            pictures: []
         };
     } 
 
@@ -34,7 +42,9 @@ class Catlist extends React.Component {
 
     componentDidUpdate(prevState, prevProps){
         if (prevState.cats.length !== this.state.catArr.length) {
-            this.setState({ catArr: this.state.catArr.concat(prevState.cats)}) 
+            this.setState({ 
+                catArr: this.state.catArr.concat(prevState.cats)
+            }) 
         }
     }
 
@@ -46,16 +56,17 @@ class Catlist extends React.Component {
         this.setState({currentIndex: this.state.currentIndex - 1})
     }
 
+    handleAddCats = (picture) => {
+        this.setState({
+            pictures: this.state.catArr.concat(picture),
+        });
+    }
+
     renderCat() {
-        let props = {
-            catArr: this.state.catArr,
-            fetchCats: this.props.fetchCats,
-            sendeCats: this.props.sendCats
-        }
         return this.props.cats.map((cat, index) => {
             return (
                 <div key={cat.id}>
-                    {this.state.showCat && this.state.currentIndex === index ? <CatDetail {...props} catUrl = {cat.url} index = {this.state.currentIndex} /> : ''}
+                    {this.state.showCat && this.state.currentIndex === index ? <CatDetail catUrl = {cat.url} index = {this.state.currentIndex} /> : ''}
                 </div>
             )
         })
@@ -75,8 +86,16 @@ class Catlist extends React.Component {
                             Prev
                             <Icon name='left arrow' />
                         </Button> 
-                        <Button icon onClick={this.props.sendCats()} >
-                            <Icon name='caret square up outline' />
+                        <Button icon onClick={this.handleAddCats} >
+                            <ImageUploader
+                                withIcon={false}
+                                withLabel={false}
+                                buttonText={'add cats'}
+                                style={hideStyles}
+                                onChange={this.handleAddCats}
+                                imgExtension={['.jpg', '.gif', '.png', '.gif']}
+                                maxFileSize={5242880}
+                            />
                         </Button>   
                         <Button 
                         icon 
@@ -99,4 +118,4 @@ const mapStateToProps = (state) => {
     return { cats: state.cats };
 }
 
-export default connect(mapStateToProps, { fetchCats, sendCats })(Catlist);
+export default connect(mapStateToProps, { fetchCats })(Catlist);

--- a/src/components/CatList.js
+++ b/src/components/CatList.js
@@ -4,32 +4,45 @@ import { fetchCats } from '../actions';
 import CatDetail from './CatDetail';
 
 class Catlist extends React.Component {
+    constructor(props) {
+        super(props);
+        // this.state = [];
+      }
 
     componentDidMount() {
         this.props.fetchCats();
-        console.log('here')
+        console.log('here mount', this.props.cats)
     }
-// const Catlist = () => {
-//     const [cat, setCat] = useState();
 
-    // useEffect(() => {
-    //     fetchCats();
-    //     console.log('here')
-    // }); 
-
-    // fetchCats();
+    // componentDidUpdate(prevProps, prevState) {
+    //     console.log(this.props.cats, this.props, this.state, 'update', prevProps, prevState,)
+    // }
+    renderCat() {
+        return this.props.cats.map(cat => {
+            return (
+                <div key={cat.id}>
+                    <div>
+                        <h2>{cat.url}</h2>
+                        <p>{cat.breed}</p>
+                    </div>
+                </div>
+            )
+        })
+    };
 
     render(){
+        console.log(this.state, 'state in render', this.props.cats)
         return (
-            <div>Catlist
+            <div>
                 <CatDetail />
+                {this.renderCat()}
             </div>
         )
     }
 };
 
-const mapStateToProps = (state) => {
-    return { cat: state.cat };
+const mapStateToProps = (state, ownProps) => {
+    return { cats: state.cats };
 }
 
 export default connect(mapStateToProps,{ fetchCats })(Catlist);

--- a/src/components/Splash.js
+++ b/src/components/Splash.js
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import styled, { keyframes } from 'styled-components';
-// import { keyframes } from "styled-components";
 import pentagram from '../images/pentagram.png';
 import fire from '../images/fire.jpg';
 import kitten1 from '../images/kitten1.png';
@@ -22,6 +21,7 @@ const BackDrop = styled.div `
     padding-bottom: 100px;
     animation: ${fade} 2s ease-in-out;
     animation-delay: 5s;
+    z-index: 10;
 `
 
 const albumCover = {

--- a/src/components/Splash.js
+++ b/src/components/Splash.js
@@ -10,6 +10,12 @@ const fade = keyframes`
     0% {opacity: 1;}
     100% {opacity: 0;}
     `
+
+const osculate = keyframes`
+    0% {opacity: 1;}
+    100% {opacity: 0;}
+`    
+
 const BackDrop = styled.div `
     height: 100%;
     width: 100%;
@@ -70,19 +76,41 @@ const kitten3Img = {
     height: '160px'
 }
 
-const laser1 = {
-    width: '200px',
-    height: '2px',
-    backgroundColor: '#FF1493',
-    transform: 'rotate(32deg) translate(90px, -43px)'
-}
+const Laser1 = styled.div `
+    width: 200px;
+    height: 2px;
+    background-color: #FF1493;
+    transform: rotate(32deg) translate(90px, -43px);
+    animation: ${osculate} 1s ease-in-out;
+    animation-iteration-count: infinite;
+`
 
-const laser2 = {
-    width: '200px',
-    height: '2px',
-    backgroundColor: '#FF1493',
-    transform: 'rotate(317deg) translate(216px, 191px)'
-}
+const Laser2 = styled.div `
+    width: 200px;
+    height: 2px;
+    background-color: #FF1493;
+    transform: rotate(317deg) translate(216px, 191px);
+    animation: ${osculate} 1s ease-in-out;
+    animation-iteration-count: infinite;
+`
+const Laser3 = styled.div `
+    width: 200px;
+    height: 2px;
+    background-color: #FF1493;
+    transform: rotate(35deg) translate(83px,-56px);
+    animation: ${osculate} 1s ease-in-out;
+    animation-iteration-count: infinite;
+    animation-delay: .5s
+`
+const Laser4 = styled.div `
+    width: 200px;
+    height: 2px;
+    background-color: #FF1493;
+    transform: rotate(314deg) translate(208px,194px);
+    animation: ${osculate} 1s ease-in-out;
+    animation-iteration-count: infinite;
+    animation-delay: .5s
+`
 
 const Splash = () => {
     const [fade, setFade]  = useState();
@@ -98,8 +126,10 @@ const Splash = () => {
             <div style={albumCover}>
                 <h1 style={bandTitle}>kittens from Hell</h1>
                 <div style={kitten3Img}>
-                    <div style={laser1} />
-                    <div style={laser2} />
+                    <Laser1 />
+                    <Laser2 />
+                    <Laser3 />
+                    <Laser4 />
                 </div>    
                 <div style={kittenContainer}>
                     <div style={kitten1Img} />

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,14 @@ import thunk from 'redux-thunk';
 import { createStore, applyMiddleware } from "redux";
 import reducers from './reducers';
 import App from './components/App';
+import './App.css';
 import * as serviceWorker from './serviceWorker';
 
 const store  = createStore(reducers, applyMiddleware(thunk));
 
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <App style={{fontFamily: 'Rock Salt'}} />
   </Provider>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import 'semantic-ui-css/semantic.min.css'
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { createStore, applyMiddleware } from "redux";

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,13 @@ import thunk from 'redux-thunk';
 import { createStore, applyMiddleware } from "redux";
 import reducers from './reducers';
 import App from './components/App';
-import './App.css';
 import * as serviceWorker from './serviceWorker';
 
 const store  = createStore(reducers, applyMiddleware(thunk));
 
 ReactDOM.render(
   <Provider store={store}>
-    <App style={{fontFamily: 'Rock Salt'}} />
+    <App />
   </Provider>,
   document.getElementById('root')
 );

--- a/src/reducers/catsReducer.js
+++ b/src/reducers/catsReducer.js
@@ -1,0 +1,8 @@
+export default (state = [], action) => {
+    switch (action.type) {
+        case 'FETCH_CATS':
+            return action.payload;
+        default:
+            return state;
+    }
+};

--- a/src/reducers/catsReducer.js
+++ b/src/reducers/catsReducer.js
@@ -1,5 +1,4 @@
 export default (state = [], action) => {
-    console.log(state, 'red')
     switch (action.type) {
         case 'FETCH_CATS':
             return action.payload;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,8 +1,7 @@
-export default (state = [], action) => {
-    switch (action.type) {
-        case 'FETCH_CATS':
-            return action.payload;
-        default:
-            return state;
-    }
-};
+import { combineReducers } from "redux";
+import catsReducer from './catsReducer';
+
+
+export default combineReducers({
+    cats: catsReducer,
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,9 @@
 import { combineReducers } from "redux";
 import catsReducer from './catsReducer';
+import sendCatsReducer from "./sendCatsReducer";
 
 
 export default combineReducers({
     cats: catsReducer,
+    sendCats: sendCatsReducer
 });

--- a/src/reducers/sendCatsReducer.js
+++ b/src/reducers/sendCatsReducer.js
@@ -1,8 +1,8 @@
 export default (state = [], action) => {
     console.log(state, 'red')
     switch (action.type) {
-        case 'FETCH_CATS':
-            return action.payload;
+        case 'SEND_CATS':
+            state.push(action.payload);
         default:
             return state;
     }

--- a/src/reducers/sendCatsReducer.js
+++ b/src/reducers/sendCatsReducer.js
@@ -1,5 +1,5 @@
 export default (state = [], action) => {
-    console.log(state, 'red')
+    console.log(state, 'red2')
     switch (action.type) {
         case 'SEND_CATS':
             state.push(action.payload);


### PR DESCRIPTION
## Description of Ticket

This feature branch adds cats to display, next and prev buttons, and image loader and adjusts CSS/styling

## Why these changes were made

These changes were made to display the cats and allow user to view the entire cat collection

## How these changes were made

These changes were made by correcting the API call to include more than one cat. Catlist component was refactored to display single cat at a time. Next/Prev buttons added to allow user to navigate through the cat collection. Image uploader package installed.

## Screenshots

<img width="763" alt="Screen Shot 2020-10-12 at 2 02 58 PM" src="https://user-images.githubusercontent.com/63467960/95785791-a56c5c00-0c93-11eb-8f67-236322666275.png">


## Known issues

The was not able to style the image uploader in a way that is good.
The image uploaded is not saved to the app. Not persistent

## Test procedures

Navigate to localhost:3000 and allow app to load.
Determine that the cat image appears after the splash screen animation disappears
Use next and prev buttons to navigate